### PR TITLE
use #' to quote functions

### DIFF
--- a/thingopt.el
+++ b/thingopt.el
@@ -209,12 +209,12 @@ This should be invoked while isearch is active.  Clobbers the current isearch st
 ;;;###autoload
 (defun kill-region-dwim ()
   (interactive)
-  (kill-region-dwim-1 'kill-region))
+  (kill-region-dwim-1 #'kill-region))
 
 ;;;###autoload
 (defun kill-ring-save-dwim ()
   (interactive)
-  (kill-region-dwim-1 'kill-ring-save))
+  (kill-region-dwim-1 #'kill-ring-save))
 
 (defun string-face-p (face)
   (let (result)


### PR DESCRIPTION
`kill-ring-save` doesn't work in latest Emacs without correct quotation. When quoting it with `function` (`#'`) everything works.

`#'`  it is similar to quote (see Quoting). But unlike quote, it also serves as a note to the Emacs evaluator and byte-compiler that function-object is intended to be used as a function. [1]

[1] http://www.gnu.org/software/emacs/manual/html_node/elisp/Anonymous-Functions.html#Anonymous-Functions
